### PR TITLE
Migrate TUI to Ratatui to fix flickering (#1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +165,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +213,20 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "core2"
@@ -277,10 +312,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -313,6 +407,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "exr"
@@ -442,6 +546,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -468,6 +574,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
@@ -522,6 +634,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +664,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -586,6 +729,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,17 +759,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "mandelbrot"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "crossbeam",
+ "crossterm",
  "float-cmp",
  "image",
  "num",
  "num_cpus",
  "rand 0.10.0",
- "termion",
+ "ratatui",
 ]
 
 [[package]]
@@ -638,6 +806,18 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -766,16 +946,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "numtoa"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "paste"
@@ -932,6 +1129,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,7 +1165,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -1002,16 +1220,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1068,6 +1320,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1378,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,16 +1420,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "termion"
-version = "4.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44138a9ae08f0f502f24104d82517ef4da7330c35acd638f1f29d3cd5475ecb"
-dependencies = [
- "libc",
- "numtoa",
 ]
 
 [[package]]
@@ -1156,6 +1463,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1507,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1274,6 +1616,116 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rand = "0.10.0"
 image = "0.25.9"
 num_cpus = "1.17.0"
 crossbeam = "0.8.4"
-termion = "4.0.6"
 float-cmp = "0.10.0"
 anyhow = "1.0"
+ratatui = { version = "0.29", features = ["crossterm"] }
+crossterm = { version = "0.28", features = ["events"] }

--- a/RATATUI.md
+++ b/RATATUI.md
@@ -1,0 +1,73 @@
+# Ratatui Migration Plan
+
+This document outlines the plan to migrate `rust-mandelbrot` from a manual `termion` renderer to the `ratatui` library. This migration will resolve the flickering issue (#1) and provide a robust framework for improving TUI fidelity (#4) and adding configuration menus (#6).
+
+## 1. Objectives
+*   **Eliminate Flickering:** Use Ratatui's internal double-buffering and diffing to only update changed cells.
+*   **Improved Layout:** Use Ratatui's layout system to manage the instruction bar and the Mandelbrot visualization area.
+*   **Cross-Platform Support:** Transition to the `crossterm` backend, which is the modern standard for Ratatui and provides better Windows support.
+*   **Foundation for High Fidelity:** Prepare for half-block rendering (`\u{2580}`) to double vertical resolution.
+
+## 2. Dependency Changes
+Add the following to `Cargo.toml`:
+```toml
+[dependencies]
+ratatui = { version = "0.29", features = ["crossterm"] }
+crossterm = { version = "0.28", features = ["event"] }
+```
+Remove `termion` once the migration is complete.
+
+## 3. Architectural Changes
+
+### 3.1 App State Structure
+Consolidate the application state into a single `App` struct:
+```rust
+struct App {
+    pixels: Vec<u8>,
+    bounds: (usize, usize),
+    window: Rect,
+    selection: Rect,
+    num_threads: usize,
+    should_quit: bool,
+}
+```
+
+### 3.2 Rendering Logic
+Refactor `terminal_render` into a function that renders to a `ratatui::Frame`:
+*   Map Mandelbrot pixels to `ratatui::widgets::canvas` or directly to `ratatui::buffer::Buffer`.
+*   Use `ratatui::style::Color::Rgb(r, g, b)` for truecolor support.
+*   Draw the selection box as a `ratatui::widgets::Block` or manual buffer manipulation.
+
+### 3.3 Event Loop
+Replace the current `stdin.events()` loop with a `ratatui` terminal loop:
+1.  Initialize `crossterm` raw mode and alternate screen.
+2.  In a loop:
+    *   `terminal.draw(|f| ui(f, &app))?`
+    *   Handle `crossterm::event::read()` for keyboard inputs.
+    *   Update `App` state based on inputs.
+
+## 4. Implementation Steps
+
+### Phase 1: Infrastructure
+1.  Update `Cargo.toml` with `ratatui` and `crossterm`.
+2.  Create `App` struct and move existing configuration logic there.
+3.  Implement terminal setup/teardown helpers (raw mode, alternate screen, mouse support).
+
+### Phase 2: Core Rendering
+1.  Implement the `ui` function to define the layout (Header + Main Area).
+2.  Convert Mandelbrot pixel mapping to write into Ratatui's `Buffer`.
+3.  Optimize the inner loop: avoid redundant color calculations by using the diffing engine's strengths.
+
+### Phase 3: Input & State
+1.  Migrate keyboard handling from `termion::event::Key` to `crossterm::event::KeyCode`.
+2.  Ensure `parallel_render` is called only when the Mandelbrot window changes (zooming).
+3.  Verify that moving the selection box only triggers a UI redraw, not a full Mandelbrot recalculation.
+
+### Phase 4: Cleanup
+1.  Remove `termion` dependency.
+2.  Validate truecolor support detection using `crossterm` or environment variables.
+
+## 5. Future Enhancements enabled by Ratatui
+*   **Split View:** Show the current render and a "preview" of the zoom area simultaneously.
+*   **Interactive Menu:** Use Ratatui's `List` or `Table` widgets for the configuration menu (#6).
+*   **Progress Bars:** Show calculation progress for high-resolution renders using `ratatui::widgets::Gauge`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,7 @@ fn ui(f: &mut Frame, app: &App) {
 fn render_mandelbrot(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let (cols, rows) = (area.width, area.height);
     let buf = f.buffer_mut();
+    let truecolor = has_truecolor();
 
     // Draw pixels
     for r in 0..rows {
@@ -316,11 +317,18 @@ fn render_mandelbrot(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             }
 
             let avg = if count > 0 { (sum / count) as u8 } else { 0 };
-            let (r, g, b) = palette(avg);
+
+            let color = if truecolor {
+                let (r, g, b) = palette(avg);
+                Color::Rgb(r, g, b)
+            } else {
+                let pixel = (avg as usize * 24 / 256) as u8;
+                Color::Indexed(232 + pixel)
+            };
 
             buf[(c_idx, r_idx)]
                 .set_char('\u{2588}')
-                .set_style(Style::default().fg(Color::Rgb(r, g, b)));
+                .set_style(Style::default().fg(color));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,21 @@ use anyhow::{anyhow, Context, Result};
 use image::ColorType;
 use num::Complex;
 use std::env;
-use std::io::{stdin, stdout, Write};
+use std::io;
 use std::str::FromStr;
-use termion::color;
-use termion::event::{Event, Key};
-use termion::input::{MouseTerminal, TermRead};
-use termion::raw::IntoRawMode;
+
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    widgets::Paragraph,
+    Frame, Terminal,
+};
+use crossterm::{
+    event::{self, Event as CEvent, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
 
 struct Config {
     file_path: String,
@@ -15,6 +24,63 @@ struct Config {
     upper_left: Complex<f64>,
     lower_right: Complex<f64>,
     num_threads: usize,
+}
+
+struct App {
+    pixels: Vec<u8>,
+    bounds: (usize, usize),
+    window: Rect,
+    moving_selection: Rect,
+    num_threads: usize,
+    numbered_file_path: String,
+}
+
+impl App {
+    fn new(config: Config) -> Self {
+        let window = Rect {
+            upper_left: config.upper_left,
+            lower_right: config.lower_right,
+        };
+        let selection = selection_from_window(&window, 0.5);
+        let numbered_file_path = increment_numbered_filename(&config.file_path);
+
+        App {
+            pixels: vec![0; config.bounds.0 * config.bounds.1],
+            bounds: config.bounds,
+            window,
+            moving_selection: selection,
+            num_threads: config.num_threads,
+            numbered_file_path,
+        }
+    }
+
+    fn update_mandelbrot(&mut self) {
+        parallel_render(
+            &mut self.pixels,
+            self.bounds,
+            self.window.upper_left,
+            self.window.lower_right,
+            self.num_threads,
+        );
+    }
+
+    fn move_selection(&mut self, cols: i32, rows: i32, terminal_size: (u16, u16)) {
+        self.moving_selection =
+            self.moving_selection
+                .move_by(&self.window, terminal_size, cols, rows);
+    }
+
+    fn zoom(&mut self) {
+        self.window.clone_from(&self.moving_selection);
+        self.moving_selection = selection_from_window(&self.window, 0.5);
+        self.update_mandelbrot();
+    }
+
+    fn save_image(&mut self) -> Result<()> {
+        write_image(&self.numbered_file_path, &self.pixels, self.bounds)?;
+        self.numbered_file_path = increment_numbered_filename(&self.numbered_file_path);
+        Ok(())
+    }
 }
 
 fn parse_args() -> Result<Config> {
@@ -62,20 +128,31 @@ fn main() -> Result<()> {
         }
     };
 
-    let window = Rect {
-        upper_left: config.upper_left,
-        lower_right: config.lower_right,
-    };
+    let mut app = App::new(config);
+    app.update_mandelbrot();
 
-    let mut pixels = vec![0; config.bounds.0 * config.bounds.1];
+    // setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, event::EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
 
-    tui_loop(
-        &config.file_path,
-        config.num_threads,
-        &mut pixels,
-        config.bounds,
-        &window,
+    // run app
+    let res = run_app(&mut terminal, &mut app);
+
+    // restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        event::DisableMouseCapture
     )?;
+    terminal.show_cursor()?;
+
+    if let Err(err) = res {
+        println!("{:?}", err)
+    }
 
     Ok(())
 }
@@ -141,122 +218,22 @@ fn complex_to_cursor_position(
     let complex_width = (window.lower_right.re - window.upper_left.re).abs();
     let complex_height = (window.upper_left.im - window.lower_right.im).abs();
 
-    let c = if complex_width > 0.0 {
-        ((complex.re - window.upper_left.re) / complex_width * (width - 1) as f64).round() as i32
+    let c = if complex_width > 0.0 && width > 1 {
+        ((complex.re - window.upper_left.re) / complex_width * (width as f64 - 1.0)).round() as i32
     } else {
         0
     };
 
-    let r = if complex_height > 0.0 {
-        ((window.upper_left.im - complex.im) / complex_height * (height - 1) as f64).round() as i32
+    let r = if complex_height > 0.0 && height > 1 {
+        ((window.upper_left.im - complex.im) / complex_height * (height as f64 - 1.0)).round() as i32
     } else {
         0
     };
 
     (
-        (c.clamp(0, width as i32 - 1) + 1) as u16,
-        (r.clamp(0, height as i32 - 1) + 1) as u16,
+        c.clamp(0, width as i32 - 1) as u16,
+        r.clamp(0, height as i32 - 1) as u16,
     )
-}
-
-/// Draw the pixels of the Mandelbrot set as best we can in the terminal
-/// https://www.unicode.org/charts/PDF/U2580.pdf
-/// Window is the complex coordinates of the window into the Mandelbrot set
-/// Selection is the current user selection for the next zoom
-fn terminal_render(
-    pixels: &[u8],
-    bounds: (usize, usize),
-    window: &Rect,
-    selection: &Rect,
-    terminal_size: (u16, u16),
-    terminal_window_offset: (u16, u16),
-) -> Result<()> {
-    let mut stdout = std::io::BufWriter::new(std::io::stdout());
-    let (cols, rows) = terminal_size;
-    let truecolor = has_truecolor();
-
-    // Draw the pixels
-    for c in 1..cols {
-        let x_start = (c - 1) as usize * bounds.0 / cols as usize;
-        let x_end = c as usize * bounds.0 / cols as usize;
-
-        for r_idx in 1..rows {
-            let y_start = (r_idx - 1) as usize * bounds.1 / rows as usize;
-            let y_end = r_idx as usize * bounds.1 / rows as usize;
-
-            let mut sum: usize = 0;
-            let mut count: usize = 0;
-            for x in x_start..x_end {
-                for y in y_start..y_end {
-                    sum += pixels[x + y * bounds.0] as usize;
-                    count += 1;
-                }
-            }
-
-            let avg = if count > 0 { (sum / count) as u8 } else { 0 };
-
-            if truecolor {
-                let (r, g, b) = palette(avg);
-                write!(
-                    stdout,
-                    "{}{}\u{2588}",
-                    termion::cursor::Goto(c + terminal_window_offset.0, r_idx + terminal_window_offset.1),
-                    termion::color::Fg(termion::color::Rgb(r, g, b))
-                )?;
-            } else {
-                let pixel = (avg as usize * 24 / 256) as u8;
-                write!(
-                    stdout,
-                    "{}{}\u{2588}",
-                    termion::cursor::Goto(c + terminal_window_offset.0, r_idx + terminal_window_offset.1),
-                    termion::color::Fg(termion::color::AnsiValue::grayscale(pixel))
-                )?;
-            }
-        }
-    }
-
-    // Draw the zoom selection
-    let (start_c, start_r) =
-        complex_to_cursor_position(&selection.upper_left, window, (cols - 1, rows - 1));
-
-    let (end_c, end_r) =
-        complex_to_cursor_position(&selection.lower_right, window, (cols - 1, rows - 1));
-
-    let selection_colour = color::AnsiValue::grayscale(20);
-
-    // Top and bottom
-    for c in start_c..=end_c {
-        write!(
-            stdout,
-            "{}{}\u{2588}",
-            termion::cursor::Goto(c + terminal_window_offset.0, start_r + terminal_window_offset.1),
-            termion::color::Fg(selection_colour)
-        )?;
-        write!(
-            stdout,
-            "{}{}\u{2588}",
-            termion::cursor::Goto(c + terminal_window_offset.0, end_r + terminal_window_offset.1),
-            termion::color::Fg(selection_colour)
-        )?;
-    }
-
-    // Sides
-    for r in start_r..=end_r {
-        write!(
-            stdout,
-            "{}{}\u{2588}",
-            termion::cursor::Goto(start_c + terminal_window_offset.0, r + terminal_window_offset.1),
-            termion::color::Fg(selection_colour)
-        )?;
-        write!(
-            stdout,
-            "{}{}\u{2588}",
-            termion::cursor::Goto(end_c + terminal_window_offset.0, r + terminal_window_offset.1),
-            termion::color::Fg(selection_colour)
-        )?;
-    }
-    stdout.flush()?;
-    Ok(())
 }
 
 fn selection_from_window(window: &Rect, _zoom: f64) -> Rect {
@@ -275,116 +252,104 @@ fn selection_from_window(window: &Rect, _zoom: f64) -> Rect {
     }
 }
 
-/// Event loop and renderer
-/// This enables the user to write the image, move and zoom the selection window 
-/// and so on.
-fn tui_loop(
-    file_path: &str,
-    num_threads: usize,
-    pixels: &mut [u8],
-    bounds: (usize, usize),
-    initial_window: &Rect,
-) -> Result<()> {
-    let mut numbered_file_path = increment_numbered_filename(file_path);
-    let zoom = 0.5f64;
-    let stdin = stdin();
-    let mut stdout = MouseTerminal::from(
-        stdout()
-            .into_raw_mode()
-            .context("failed to set raw mode")?,
-    );
+fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> io::Result<()> {
+    loop {
+        terminal.draw(|f| ui(f, app))?;
 
-    let mut ts = termion::terminal_size().context("failed to get terminal size")?;
-    let mut window = initial_window.clone();
+        if event::poll(std::time::Duration::from_millis(16))? {
+            if let CEvent::Key(key) = event::read()? {
+                let size = terminal.size()?;
+                let mandelbrot_area = (size.width, size.height.saturating_sub(1));
 
-    let selection = selection_from_window(&window, zoom);
-
-    // Temp for debugging in IntelliJ the terminal has zero size
-    if ts.0 == 0 {
-        ts = (120, 80);
-    }
-
-    write!(
-        stdout,
-        "{}{}Esc to exit - wasd to move selection - Enter to write current image file and z to zoom",
-        termion::clear::All,
-        termion::cursor::Goto(1, 1)
-    )
-    .context("failed to write to stdout")?;
-
-    // Render the image to the pizel array
-    parallel_render(
-        pixels,
-        bounds,
-        window.upper_left,
-        window.lower_right,
-        num_threads,
-    );
-    terminal_render(
-        pixels,
-        bounds,
-        &window,
-        &selection,
-        (ts.0, ts.1 - 1),
-        (0, 1),
-    )?;
-    stdout.flush().context("failed to flush stdout")?;
-
-    let mut moving_selection = selection.clone();
-
-    let terminal_bounds = (ts.0, ts.1 - 1);
-
-    for c in stdin.events() {
-        let evt = c.context("failed to read event")?;
-        if let Event::Key(key) = evt {
-            match key {
-                Key::Esc => {
-                    write!(stdout, "{}", termion::clear::All).context("failed to clear screen")?;
-                    break;
+                match key.code {
+                    KeyCode::Esc => return Ok(()),
+                    KeyCode::Char('a') => app.move_selection(-1, 0, mandelbrot_area),
+                    KeyCode::Char('d') => app.move_selection(1, 0, mandelbrot_area),
+                    KeyCode::Char('w') => app.move_selection(0, 1, mandelbrot_area),
+                    KeyCode::Char('s') => app.move_selection(0, -1, mandelbrot_area),
+                    KeyCode::Char('z') => app.zoom(),
+                    KeyCode::Enter => {
+                        app.save_image().expect("failed to save image");
+                    }
+                    _ => {}
                 }
-                Key::Char('a') => {
-                    moving_selection = moving_selection.move_by(&window, terminal_bounds, -1, 0);
-                }
-                Key::Char('d') => {
-                    moving_selection = moving_selection.move_by(&window, terminal_bounds, 1, 0);
-                }
-                Key::Char('w') => {
-                    moving_selection = moving_selection.move_by(&window, terminal_bounds, 0, 1);
-                }
-                Key::Char('s') => {
-                    moving_selection = moving_selection.move_by(&window, terminal_bounds, 0, -1);
-                }
-
-                Key::Char('\n') => {
-                    write_image(&numbered_file_path, pixels, bounds)
-                        .context("error writing PNG file")?;
-                    numbered_file_path = increment_numbered_filename(&numbered_file_path);
-                }
-                Key::Char('z') => {
-                    window.clone_from(&moving_selection);
-                    moving_selection = selection_from_window(&window, zoom);
-                    parallel_render(
-                        pixels,
-                        bounds,
-                        window.upper_left,
-                        window.lower_right,
-                        num_threads,
-                    );
-                }
-                _ => {}
             }
         }
-        terminal_render(
-            pixels,
-            bounds,
-            &window,
-            &moving_selection,
-            (ts.0, ts.1 - 1),
-            (0, 1),
-        )?;
-        stdout.flush().context("failed to flush stdout")?;
     }
-    Ok(())
+}
+
+fn ui(f: &mut Frame, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(f.area());
+
+    let help_text = "Esc to exit - wasd to move selection - Enter to write current image file and z to zoom";
+    let help_paragraph = Paragraph::new(help_text);
+    f.render_widget(help_paragraph, chunks[0]);
+
+    render_mandelbrot(f, app, chunks[1]);
+}
+
+fn render_mandelbrot(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
+    let (cols, rows) = (area.width, area.height);
+    let buf = f.buffer_mut();
+
+    // Draw pixels
+    for r in 0..rows {
+        let r_idx = area.y + r;
+        let y_start = r as usize * app.bounds.1 / rows as usize;
+        let y_end = (r + 1) as usize * app.bounds.1 / rows as usize;
+
+        for c in 0..cols {
+            let c_idx = area.x + c;
+            let x_start = c as usize * app.bounds.0 / cols as usize;
+            let x_end = (c + 1) as usize * app.bounds.0 / cols as usize;
+
+            let mut sum: usize = 0;
+            let mut count: usize = 0;
+            for x in x_start..x_end {
+                for y in y_start..y_end {
+                    sum += app.pixels[x + y * app.bounds.0] as usize;
+                    count += 1;
+                }
+            }
+
+            let avg = if count > 0 { (sum / count) as u8 } else { 0 };
+            let (r, g, b) = palette(avg);
+
+            buf[(c_idx, r_idx)]
+                .set_char('\u{2588}')
+                .set_style(Style::default().fg(Color::Rgb(r, g, b)));
+        }
+    }
+
+    // Draw selection
+    let (start_c, start_r) =
+        complex_to_cursor_position(&app.moving_selection.upper_left, &app.window, (cols, rows));
+    let (end_c, end_r) =
+        complex_to_cursor_position(&app.moving_selection.lower_right, &app.window, (cols, rows));
+
+    let selection_style = Style::default().fg(Color::Indexed(20));
+
+    // Top & Bottom
+    for c in start_c..=end_c {
+        if c < cols {
+            buf[(area.x + c, area.y + start_r)]
+                .set_style(selection_style);
+            buf[(area.x + c, area.y + end_r)]
+                .set_style(selection_style);
+        }
+    }
+    // Sides
+    for r in start_r..=end_r {
+        if r < rows {
+            buf[(area.x + start_c, area.y + r)]
+                .set_style(selection_style);
+            buf[(area.x + end_c, area.y + r)]
+                .set_style(selection_style);
+        }
+    }
 }
 
 /// Given a pixel array, bounds and window co-ordinates and number of threads to use
@@ -623,9 +588,9 @@ mod tests {
 
         let terminal_size = (200, 200);
         let (c, r) = complex_to_cursor_position(&selection.upper_left, &window, terminal_size);
-        // (25-0)/100 * 199 = 49.75 -> 50. 50 + 1 = 51.
-        // (100-75)/100 * 199 = 49.75 -> 50. 50 + 1 = 51.
-        assert_eq!((c, r), (51, 51));
+        // (25-0)/100 * 199 = 49.75 -> 50.
+        // (100-75)/100 * 199 = 49.75 -> 50.
+        assert_eq!((c, r), (50, 50));
     }
 
     #[test]


### PR DESCRIPTION
This PR migrates the TUI from a manual termion renderer to Ratatui. Key changes include:\n- Use of Ratatui's double-buffering to eliminate flickering when moving the selection window.\n- Consolidation of application state into a unified App struct.\n- Addition of truecolor support with 256-color fallback.\n- Clean up of unused imports and deprecated methods.